### PR TITLE
Classes for pickup estimated time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New CSS Handler to the pickup estimate time in Store List.
+
 ## [0.1.0] - 2020-03-17
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,14 +13,15 @@ This component uses the `ProductContext` and is meant to be used inside the `sto
 
 In order to apply CSS customizations on this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles                   |
-| ----------------------------- |
-| `availabilityAction`          |
-| `availabilityButtonContainer` |
-| `availabilityHeader`          |
-| `availabilityMessage`         |
-| `container`                   |
-| `innerContainer`              |
+| CSS Handles                         |
+| ------------------------------------|
+| `availabilityAction`                |
+| `availabilityButtonContainer`       |
+| `availabilityHeader`                |
+| `availabilityMessage`               |
+| `container`                         |
+| `innerContainer`                    |
+| `shippingEstimate[--]{timeModifier}`|
 
 ## Contributors ✨
 

--- a/react/components/StorePickupItem.tsx
+++ b/react/components/StorePickupItem.tsx
@@ -22,7 +22,7 @@ const StorePickupItem: FC<Props> = ({ store }) => {
     <div className={`flex flex-column t-body lh-copy c-muted-2 ${handles.pickupItem}`}>
       <span className={`t-heading-6 c-on-base ${handles.pickupName}`}>{`${friendlyName}`}</span>
       <span className={handles.pickupAddress}>{`${address.street}${address.number ? `, ${address.number}` : ''}`}</span>
-      <div className={`${shippingEstimate ? `${handles.pickupEstimate} ${handles.pickupEstimate}-${shippingEstimate}` : handles.pickupUnavailable} flex`}>
+      <div className={`${shippingEstimate ? `${handles.pickupEstimate} ${handles.pickupEstimate}--${shippingEstimate}` : handles.pickupUnavailable} flex`}>
         {shippingEstimate ? (
           <FormattedMessage id="store/pickup-availability.pickup-estimate" values={{ estimate }} />
         ) : (

--- a/react/components/StorePickupItem.tsx
+++ b/react/components/StorePickupItem.tsx
@@ -22,7 +22,7 @@ const StorePickupItem: FC<Props> = ({ store }) => {
     <div className={`flex flex-column t-body lh-copy c-muted-2 ${handles.pickupItem}`}>
       <span className={`t-heading-6 c-on-base ${handles.pickupName}`}>{`${friendlyName}`}</span>
       <span className={handles.pickupAddress}>{`${address.street}${address.number ? `, ${address.number}` : ''}`}</span>
-      <div className={`${shippingEstimate ? handles.pickupEstimate : handles.pickupUnavailable} flex`}>
+      <div className={`${shippingEstimate ? `${handles.pickupEstimate} ${handles.pickupEstimate}-${shippingEstimate}` : handles.pickupUnavailable} flex`}>
         {shippingEstimate ? (
           <FormattedMessage id="store/pickup-availability.pickup-estimate" values={{ estimate }} />
         ) : (

--- a/react/components/StorePickupItem.tsx
+++ b/react/components/StorePickupItem.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import TranslateEstimate from 'vtex.shipping-estimate-translator/TranslateEstimate'
 import { FormattedMessage } from 'react-intl'
-import { useCssHandles } from 'vtex.css-handles'
+import { applyModifiers, useCssHandles } from 'vtex.css-handles'
 
 const CSS_HANDLES = ['estimateTranslated', 'pickupItem', 'pickupName', 'pickupAddress', 'pickupEstimate', 'pickupUnavailable'] as const
 
@@ -22,7 +22,9 @@ const StorePickupItem: FC<Props> = ({ store }) => {
     <div className={`flex flex-column t-body lh-copy c-muted-2 ${handles.pickupItem}`}>
       <span className={`t-heading-6 c-on-base ${handles.pickupName}`}>{`${friendlyName}`}</span>
       <span className={handles.pickupAddress}>{`${address.street}${address.number ? `, ${address.number}` : ''}`}</span>
-      <div className={`${shippingEstimate ? `${handles.pickupEstimate} ${handles.pickupEstimate}--${shippingEstimate}` : handles.pickupUnavailable} flex`}>
+      <div className={`${shippingEstimate ?
+        applyModifiers(handles.pickupEstimate, shippingEstimate) :
+        handles.pickupUnavailable} flex`}>
         {shippingEstimate ? (
           <FormattedMessage id="store/pickup-availability.pickup-estimate" values={{ estimate }} />
         ) : (


### PR DESCRIPTION
#### What problem is this solving?
Adding the shipping estimate time to an additional class on each `StorePickupItem`, then we are able to add custom styles depending on Shipping Estimated, such as applying highlights or whatever.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://bruno--eriksbikeshop.myvtex.com/specialized-2020-echelon-ii-mips-helmet-pr3e18228/p?skuId=8016889)

Select a SKU, click "Find Store", type "minneapolis", select the first address option and look the magic.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/27451066/80729899-40ef8300-8adf-11ea-8c22-68a4266bcff3.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

`styles/css/vtex.pickup-availability.css`
```css
.pickupEstimate-2bd:after {
  content: 'In Stock';
  margin-left: 10px;
  background-color: green;
}

.pickupEstimate:not(.pickupEstimate-2bd):after {
  content: 'Available for Transfer';
  margin-left: 10px;
  background-color: yellow;
}

.pickupUnavailable:after {
  content: 'Not Availalable At This Location';
  margin-left: 10px;
  background-color: red;
}
```

<!-- Put any relevant information that doesn't fit in the other sections here. -->
