### PR TITLE
added css handler for pickupa address select message

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `container`                         |
 | `innerContainer`                    |
 | `shippingEstimate[--]{timeModifier}`|
+| `addressMessage                    `|
 
 ## Contributors ✨
 

--- a/react/components/AddressInput.tsx
+++ b/react/components/AddressInput.tsx
@@ -2,10 +2,12 @@ import React, { Fragment, PureComponent } from 'react'
 import { withScriptjs, WithScriptjsProps } from 'react-google-maps'
 import { withRuntimeContext, RenderContextProps } from 'vtex.render-runtime'
 import ReactGoogleAutocomplete from './ReactGooogleAutocomplete'
-import { FormattedMessage, injectIntl, InjectedIntlProps } from 'react-intl'
+import { injectIntl, InjectedIntlProps } from 'react-intl'
+import AddressInputMessage from './AddressInputMessage'
 
 const GEOLOCATION_TIMEOUT = 30 * 1000
 const MAXIMUM_AGE = 3 * 1000
+
 
 const getCurrentPositionPromise = (): Promise<Position> => {
   const geolocationOptions = {
@@ -110,9 +112,7 @@ class AddressInput extends PureComponent<Props & WithScriptjsProps & RenderConte
 
     return (
       <Fragment>
-        <div className="t-body c-on-base mv4">
-          <FormattedMessage id="store/pickup-availability.input-form-header" />
-        </div>
+        <AddressInputMessage />
         <ReactGoogleAutocomplete
           isLoading={false}
           isFetchingPosition={this.state.isFetchingPosition}

--- a/react/components/AddressInputMessage.tsx
+++ b/react/components/AddressInputMessage.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = ['addressMessage']
+
+const AddressInputMessage = () => {
+  const handles = useCssHandles(CSS_HANDLES)
+  return (
+    <div className={`t-body c-on-base mv4 ${handles.addressMessage}`}>
+      <FormattedMessage id="store/pickup-availability.input-form-header" />
+    </div>
+  )
+}
+
+export default AddressInputMessage


### PR DESCRIPTION
#### What problem is this solving?

It adds css handles to the message for location pickup selector so it can be styled.

#### How to test it?

Using the link, click on "Alegeti magazinul" and inspect the message "Alegeți o adresă pentru a găsi un magazin".

[Workspace] https://claudiu--fstudio.myvtex.com/nikon-d750-body/p

#### Screenshots or example usage:

![Screenshot from 2020-11-26 15-01-37](https://user-images.githubusercontent.com/73105476/100354129-520e5d00-2ff8-11eb-9692-18e05e0a154c.png)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
